### PR TITLE
added compatibility with django 1.10

### DIFF
--- a/cuser/middleware.py
+++ b/cuser/middleware.py
@@ -1,9 +1,12 @@
 from __future__ import unicode_literals
 import threading
+
+from django.utils.deprecation import MiddlewareMixin
+
 from cuser.compat import User
 
 
-class CuserMiddleware(object):
+class CuserMiddleware(MiddlewareMixin):
     """
     Always have access to the current user
     """


### PR DESCRIPTION
In order to be compatible with the new middleware style classes of django 1.10, the middleware need to derive from the MiddlewareMixin. I have added this in this pull request.
